### PR TITLE
Use checked in yarn version to prevent Dojo assets breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "name": "defect-dojo",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": "^8.10.0",
+    "yarn": "1.21.0"
+  },
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",
     "bootstrap": "twbs/bootstrap#~3.3.7",
@@ -32,8 +39,5 @@
   },
   "devDependencies": {
     "mocha": "mochajs/mocha#~1.17.1"
-  },
-  "engines": {
-    "yarn": ">= 1.0.0"
   }
 }


### PR DESCRIPTION
Yarn allows you to check a version in that the system version will defer to if it finds it. This adds a checked in version for consistency and to avoid an issue in launching Dojo caused by 1.22.x

Using `yarn policies set-version v1.21.0` in the setup scripts should make things work okay.